### PR TITLE
Add retry-failed subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ NOTE: dbt-helper may not work with dbt when dbt is installed via homebrew. We ar
 * `show_upstream`: Inspect the dbt graph and show the relations that are "upstream" from (i.e., the "parents" of) the selected relation. Print to the terminal.
 * `show_downstream`: The same as `show_upstream` but in the other direction -- show dependents 'downstream' from (i.e., the "children" of) the selected relation
 * `open`: Open the compiled `.sql` file for a model by providing the model name only. You can also open the source or run `.sql` files for a model by using the appropriate flag. Useful when working in large dbt projects and you want to open files quickly wihout having to navigate a file tree.
+* `retry-failed`: Rerun models that errored or were skipped on your previous dbt run.
 
 As one might hope, you can view the command line options directly from the tool by using the help functionality:
 
@@ -126,6 +127,24 @@ applications (e.g. git prompts launch in the editor specified here). If this is
 not set, then use:
 * `"Open"`: Generic command that will open a file in the default application for
 the associated file type.
+
+
+#### `retry-failed`
+```bash
+$ dbt-helper retry-failed
+dbt run --models my_failed_model my_skipped_model
+Running with dbt=0.13.0
+Found 8 models, 20 tests, 0 archives, 0 analyses, 113 macros, 0 operations, 3 seed files, 0 sources
+
+17:40:11 | Concurrency: 1 threads (target='dev')
+17:40:11 |
+17:40:11 | 1 of 2 START view model dev_example.my_failed_model.................. [RUN]
+17:40:12 | 1 of 2 OK created view model dev_example.my_failed_model............. [CREATE VIEW in 0.65s]
+17:40:12 | 2 of 2 START table model dev_example.my_skipped_model................ [RUN]
+17:40:29 | 2 of 2 OK created table model dev_example.my_skipped_model........... [SELECT in 16.86s]
+17:41:31 |
+17:41:31 | Finished running 1 view models, 1 table models in 80.96s.
+```
 
 ## Contributing
 

--- a/core/main.py
+++ b/core/main.py
@@ -6,6 +6,7 @@ import core.bootstrap as bootstrap_task
 import core.compare as compare_task
 import core.show_dependencies as show_dependencies_task
 import core.open as open_task
+import core.retry_failed as retry_failed_task
 
 from dbt.config import PROFILES_DIR
 
@@ -160,6 +161,17 @@ def parse_args(args):
             statements), from the target/run directory.""",
     )
 
+    retry_failed_sub = subs.add_parser(
+        "retry-failed",
+        parents=[base_subparser],
+        help="""
+            Rerun the models that failed or were skipped on the previous run.""",
+    )
+
+    retry_failed_sub.set_defaults(
+        cls=retry_failed_task.RetryFailedTask, which="retry-failed"
+    )
+
     if len(args) == 0:
         p.print_help()
         sys.exit(1)
@@ -197,6 +209,10 @@ def handle(args):
 
     if parsed.command == "open":
         task = open_task.OpenTask(parsed)
+        results = task.run()
+
+    if parsed.command == "retry-failed":
+        task = retry_failed_task.RetryFailedTask(parsed)
         results = task.run()
 
     return results

--- a/core/retry_failed.py
+++ b/core/retry_failed.py
@@ -1,0 +1,63 @@
+from dbt.config import RuntimeConfig
+
+import os
+import json
+import subprocess
+
+RUN_RESULTS_FILE = "run_results.json"
+
+
+class RetryFailedTask:
+    def __init__(self, args):
+        self.args = args
+        self.config = RuntimeConfig.from_args(args)
+        self.target_path = self.config.target_path
+        self.run_results = self._get_run_results()
+
+    def _get_run_results(self):
+        """
+        This subcommand parses the results.json file
+        """
+        run_results_path = os.path.join(self.target_path, RUN_RESULTS_FILE)
+        try:
+            with open(run_results_path) as f:
+                run_results = json.load(f)
+            return run_results
+        except IOError:
+            raise Exception("Could not find {} file.".format(RUN_RESULTS_FILE))
+
+    def get_models_to_retry(self):
+        """ Return a list of errored and skipped models
+        """
+        models = []
+        for result in self.run_results.get("results"):
+            if result["status"] == "ERROR" or result["skip"]:
+                models.append(result["node"]["name"])
+        return models
+
+    def get_run_flags(self):
+        """ This is a janky function that takes the args and puts them back
+        into a list of strings."""
+        flags = []
+        if self.args.profiles_dir:
+            flags.extend(["--profiles-dir", self.args.profiles_dir])
+        if self.args.profile:
+            flags.extend(["--profile", self.args.profile])
+        if self.args.target:
+            flags.extend(["--target", self.args.target])
+        return flags
+
+    def run(self):
+        models_to_retry = self.get_models_to_retry()
+
+        if models_to_retry == []:
+            raise Exception("No models to rerun!")
+
+        run_flags = self.get_run_flags()
+
+        command = " ".join(["dbt run --models ", *models_to_retry, *run_flags])
+
+        print(command)
+        subprocess.call(command, shell=True)
+
+        return models_to_retry

--- a/core/retry_failed.py
+++ b/core/retry_failed.py
@@ -55,7 +55,11 @@ class RetryFailedTask:
 
         run_flags = self.get_run_flags()
 
-        command = " ".join(["dbt run --models ", *models_to_retry, *run_flags])
+        args = ["dbt run --models"]
+        args.extend(models_to_retry)
+        args.extend(run_flags)
+
+        command = " ".join(args)
 
         print(command)
         subprocess.call(command, shell=True)

--- a/test/integration/008_retry_failed_test/models/my_failing_model.sql
+++ b/test/integration/008_retry_failed_test/models/my_failing_model.sql
@@ -1,0 +1,2 @@
+-- depends on {{ ref('my_passing_model') }}
+This is invalid SQL

--- a/test/integration/008_retry_failed_test/models/my_passing_model.sql
+++ b/test/integration/008_retry_failed_test/models/my_passing_model.sql
@@ -1,0 +1,1 @@
+select 1 as colname

--- a/test/integration/008_retry_failed_test/models/my_skipped_model.sql
+++ b/test/integration/008_retry_failed_test/models/my_skipped_model.sql
@@ -1,0 +1,2 @@
+-- depends on {{ ref('my_failing_model') }}
+select 1 as colname

--- a/test/integration/008_retry_failed_test/test_retry_failed.py
+++ b/test/integration/008_retry_failed_test/test_retry_failed.py
@@ -7,8 +7,11 @@ class RetryFailedTest(DBTIntegrationTest):
         return "test/integration/008_retry_failed_test/models"
 
     def tests_retry_failed(self):
-        try:
-            self.run_dbt(["run"])
-        except InvocationError:
-            pass
-        self.assertEqual(self.run_dbthelper(["retry-failed"]), ["my_failing_model", "my_skipped_model"])
+        _, success = self.run_dbt(["run"])
+
+        self.assertFalse(success)
+
+        self.assertEqual(
+            self.run_dbthelper(["retry-failed"]),
+            ["my_failing_model", "my_skipped_model"],
+        )

--- a/test/integration/008_retry_failed_test/test_retry_failed.py
+++ b/test/integration/008_retry_failed_test/test_retry_failed.py
@@ -1,0 +1,14 @@
+from test.integration.base import DBTIntegrationTest
+
+
+class RetryFailedTest(DBTIntegrationTest):
+    @property
+    def models(self):
+        return "test/integration/008_retry_failed_test/models"
+
+    def tests_retry_failed(self):
+        try:
+            self.run_dbt(["run"])
+        except InvocationError:
+            pass
+        self.assertEqual(self.run_dbthelper(["retry-failed"]), ["my_failing_model", "my_skipped_model"])

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -202,3 +202,5 @@ class DBTIntegrationTest(unittest.TestCase):
         args.extend(["--profiles-dir", self.dbt_config_dir])
 
         res, success = handle_and_check(args)
+
+        return res, success


### PR DESCRIPTION
This command is useful when your run didn't complete successfully, and you want to rerun the models that error-ed or were skipped in the previous run.

I wanted to keep writing python so gave this a go.

I'm not 100% convinced that a python script is the best way to go to solve this problem though, and doing it in bash may be the more reasonable solution, buuuuut I don't know enough about bash to tackle the problem that way.

Thoughts? Does this belong in this repo?

Also docs to come pending the above.