### PR TITLE
Fix argument order in pip install dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ target/
 build/
 dist/
 /dbt_project.yml
+.vscode
+.mypy_cache

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Found 8 models, 20 tests, 0 archives, 0 analyses, 113 macros, 0 operations, 3 se
 Install locally for development:
 
 ```
-pip install . -e
+pip install -e .
 ```
 
 ### Conventions


### PR DESCRIPTION
# Description

When I copied blindly the pip install dev instructions from the readme pip complained about the argument order.

I checked what I had copied 👀 and yeah looks like the order isn't the right one, unless something is fucked up in my pip but I wouldn't think so.

So here's a PR to fix this.

**Note:** I had to `.gitignore` a few vscode and mypy specific things. VScode workspace setting is gonna be a hard one to negociate I think (as far as I know). Happy to stop linting with mypy and remove that hidden file though as it's not part of your standards in contributing.

## How was this tested?
Ran corrected install instructions in my machine. No further tests required.