### PR TITLE
Pin dbt version at <0.14.0 for compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # `dbt-helper` (beta)
 
+NOTE: `dbt-helper` currently only works with dbt version < 0.15.0. If you're using `dbt-helper` and you'd like to contribute to fixing the compatability issues, please reach out!
+
 NOTE: `dbt-helper` is still in extremely-limited beta release. We'd love your help, testing it though! Until we're out of beta, please don't build this into anything production-touching as it will surely get broken sooner rather than later
 
 `dbt-helper` is a command line tool that helps with developing [`dbt`](https://www.getdbt.com/) projects and managing data warehouses.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `dbt-helper` (beta)
 
-NOTE: `dbt-helper` currently only works with dbt version < 0.15.0. If you're using `dbt-helper` and you'd like to contribute to fixing the compatability issues, please reach out!
+NOTE: `dbt-helper` currently only works with dbt version < 0.14.0. If you're using `dbt-helper` and you'd like to contribute to fixing the compatability issues, please reach out!
 
 NOTE: `dbt-helper` is still in extremely-limited beta release. We'd love your help, testing it though! Until we're out of beta, please don't build this into anything production-touching as it will surely get broken sooner rather than later
 

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,6 @@ setup(
     test_suite="test",
     entry_points={"console_scripts": ["dbt-helper = core.main:main"]},
     scripts=[],
-    install_requires=["dbt"],
+    install_requires=["dbt<0.15.0"],
     cmdclass={"verify": VerifyVersionCommand},
 )

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,6 @@ setup(
     test_suite="test",
     entry_points={"console_scripts": ["dbt-helper = core.main:main"]},
     scripts=[],
-    install_requires=["dbt<0.15.0"],
+    install_requires=["dbt<0.14.0"],
     cmdclass={"verify": VerifyVersionCommand},
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36
+envlist = py36
 
 [testenv]
 # install pytest in the virtualenv where commands will be executed
@@ -13,4 +13,4 @@ commands =
     flake8
 
 [testenv:dev]
-envlist = py37
+envlist = py36


### PR DESCRIPTION
Addresses https://github.com/mikekaminsky/dbt-helper/issues/25

Turns out the `compare` function actually breaks at `dbt 0.14.0` so I've pinned this repo there for now.