### PR TITLE
Fix: standardize subcommands to use '-' instead of '_'

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ NOTE: dbt-helper may not work with dbt when dbt is installed via homebrew. We ar
   * Note: `dbt-helper compare` will compare all schemas that are impacted by models in the `models/` directory. There is (currently) no way to specify a single schema to compare.
 * `bootstrap`: Create starter "`schema.yml`" files for your project. This function helpfully generates boilerplate dbt-model files for you so you don't have to go through the copy/paste when you're developing a new model.
   * Note: this command will not over-write existing `schema.yml` files. It will default to printing templates to the console, but you can create new files by using the `--write-files` flag.
-* `show_upstream`: Inspect the dbt graph and show the relations that are "upstream" from (i.e., the "parents" of) the selected relation. Print to the terminal.
-* `show_downstream`: The same as `show_upstream` but in the other direction -- show dependents 'downstream' from (i.e., the "children" of) the selected relation
+* `show-upstream`: Inspect the dbt graph and show the relations that are "upstream" from (i.e., the "parents" of) the selected relation. Print to the terminal.
+* `show-downstream`: The same as `show-upstream` but in the other direction -- show dependents 'downstream' from (i.e., the "children" of) the selected relation
 * `find`: Find the compiled `.sql` file for a model by providing the model name only. You can also find the source or run `.sql` files for a model by using the appropriate flag. Useful when working in large dbt projects and you want to find files quickly wihout having to navigate a file tree.
 * `open`: Open the compiled `.sql` file for a model by providing the model name only. Works the same as find, but directly opens the file in your text editor.
 * `retry-failed`: Rerun models that errored or were skipped on your previous dbt run.
@@ -78,9 +78,9 @@ models:
   description: 'TODO: Replace me'
 ```
 
-#### `show_upstream`
+#### `show-upstream`
 ```bash
-$ dbt-helper show_upstream d
+$ dbt-helper show-upstream d
 
 --------------------------------------------------------------------------------
                                   downstream.d
@@ -89,8 +89,8 @@ $ dbt-helper show_upstream d
 --------------------------------------------------------------------------------
 ```
 
-#### `show_downstream`
-_see `show_upstream`_
+#### `show-downstream`
+_see `show-upstream`_
 
 #### `find`
 

--- a/core/bootstrap.py
+++ b/core/bootstrap.py
@@ -81,7 +81,10 @@ class BootstrapTask:
         """
         nodes, sources = Catalog(columns).make_unique_id_map(manifest)
         result = CatalogResults(
-            nodes=nodes, sources=sources, generated_at=datetime.utcnow(), errors=None,
+            nodes=nodes,
+            sources=sources,
+            generated_at=datetime.utcnow(),
+            errors=None,
         )
         return result.to_dict(omit_none=False)["nodes"]
 

--- a/core/find.py
+++ b/core/find.py
@@ -36,7 +36,7 @@ class FindTask:
             )
 
     def _get_model_files(self):
-        """ Return a dictionary of the form:
+        """Return a dictionary of the form:
         {
             'source': 'models/path/to/model',
             'compiled': 'target/compiled/path/to/model',

--- a/core/main.py
+++ b/core/main.py
@@ -9,6 +9,9 @@ import core.open as open_task
 import core.find as find_task
 import core.retry_failed as retry_failed_task
 
+import utils.ui
+from utils.logging import logger
+
 from dbt.config import PROFILES_DIR
 from dbt.version import get_installed_version
 
@@ -121,22 +124,23 @@ def parse_args(args):
     )
 
     upstream_depencies_sub = subs.add_parser(
-        "show_upstream",
+        "show-upstream",
         parents=[base_subparser],
         help="Show upstream dependencies for a model",
     )
     upstream_depencies_sub.set_defaults(
-        cls=show_dependencies_task.ShowDependenciesTask, which="show_upstream"
+        cls=show_dependencies_task.ShowDependenciesTask, which="show-upstream"
     )
     upstream_depencies_sub.add_argument("model_name")
 
     downstream_depencies_sub = subs.add_parser(
-        "show_downstream",
+        "show-downstream",
+        aliases=['show_downstream'],
         parents=[base_subparser],
         help="Show downstream dependencies for a model",
     )
     downstream_depencies_sub.set_defaults(
-        cls=show_dependencies_task.ShowDependenciesTask, which="show_downstream"
+        cls=show_dependencies_task.ShowDependenciesTask, which="show-downstream"
     )
     downstream_depencies_sub.add_argument("model_name")
 
@@ -232,8 +236,22 @@ def handle(args):
     if parsed.command == "compare":
         task = compare_task.CompareTask(parsed)
         results = task.run()
-
+    
     if parsed.command in ("show_upstream", "show_downstream"):
+        logger.info(
+                utils.ui.yellow(
+                    "Deprecation Warning: \n"
+                    "show_upstream and show_downstream will be deprecated in \n"
+                    "a future version of dbt-helper in favor of the more \n"
+                    "consistent show-upstream and show-downstream syntax."
+                )
+            )
+        if parsed.command == "show_upstream":
+            parsed.command = "show-upstream"
+        else:
+            parsed.command = "show-downstream"
+
+    if parsed.command in ("show-upstream", "show-downstream"):
         task = show_dependencies_task.ShowDependenciesTask(parsed)
         results = task.run(parsed)
 

--- a/core/main.py
+++ b/core/main.py
@@ -68,7 +68,8 @@ def parse_args(args):
         ),
     )
     base_subparser.add_argument(
-        "--project-dir", help="Project directory specification",
+        "--project-dir",
+        help="Project directory specification",
     )
     base_subparser.add_argument(
         "--profile",
@@ -135,7 +136,7 @@ def parse_args(args):
 
     downstream_depencies_sub = subs.add_parser(
         "show-downstream",
-        aliases=['show_downstream'],
+        aliases=["show_downstream"],
         parents=[base_subparser],
         help="Show downstream dependencies for a model",
     )
@@ -236,16 +237,16 @@ def handle(args):
     if parsed.command == "compare":
         task = compare_task.CompareTask(parsed)
         results = task.run()
-    
+
     if parsed.command in ("show_upstream", "show_downstream"):
         logger.info(
-                utils.ui.yellow(
-                    "Deprecation Warning: \n"
-                    "show_upstream and show_downstream will be deprecated in \n"
-                    "a future version of dbt-helper in favor of the more \n"
-                    "consistent show-upstream and show-downstream syntax."
-                )
+            utils.ui.yellow(
+                "Deprecation Warning: \n"
+                "show_upstream and show_downstream will be deprecated in \n"
+                "a future version of dbt-helper in favor of the more \n"
+                "consistent show-upstream and show-downstream syntax."
             )
+        )
         if parsed.command == "show_upstream":
             parsed.command = "show-upstream"
         else:

--- a/core/retry_failed.py
+++ b/core/retry_failed.py
@@ -27,8 +27,7 @@ class RetryFailedTask:
             raise Exception("Could not find {} file.".format(RUN_RESULTS_FILE))
 
     def get_models_to_retry(self):
-        """ Return a list of errored and skipped models
-        """
+        """Return a list of errored and skipped models"""
         models = []
         for result in self.run_results.get("results"):
             if result["status"] == "ERROR" or result["skip"]:
@@ -36,7 +35,7 @@ class RetryFailedTask:
         return models
 
     def get_run_flags(self):
-        """ This is a janky function that takes the args and puts them back
+        """This is a janky function that takes the args and puts them back
         into a list of strings."""
         flags = []
         if self.args.profiles_dir:

--- a/core/show_dependencies.py
+++ b/core/show_dependencies.py
@@ -8,9 +8,9 @@ from utils.logging import logger
 class ShowDependenciesTask:
     def __init__(self, args):
         self.args = args
-        if self.args.command == "show_upstream":
+        if self.args.command == "show-upstream":
             self.direction = "upstream"
-        elif self.args.command == "show_downstream":
+        elif self.args.command == "show-downstream":
             self.direction = "downstream"
         else:
             raise

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools.command.install import install
 
 
 package_name = "dbt-helper"
-VERSION = "0.4.1"
+VERSION = "0.5.0"
 description = """dbt-helper is a command line tool to help ease dbt development and database management"""
 
 

--- a/test/integration/005_dependency_viewer_test/test_dependency_viewer.py
+++ b/test/integration/005_dependency_viewer_test/test_dependency_viewer.py
@@ -4,16 +4,16 @@ from test.integration.base import DBTIntegrationTest
 class DependencyTest(DBTIntegrationTest):
     def test_dependencies(self):
         self.run_dbt(["run"])
-        results = self.run_dbthelper(["show_upstream", "d"])
+        results = self.run_dbthelper(["show-upstream", "d"])
         self.assertTrue(len(results) == 4)
-        results = self.run_dbthelper(["show_downstream", "d"])
+        results = self.run_dbthelper(["show-downstream", "d"])
         self.assertTrue(len(results) == 1)
-        results = self.run_dbthelper(["show_upstream", "c"])
+        results = self.run_dbthelper(["show-upstream", "c"])
         self.assertTrue(len(results) == 3)
-        results = self.run_dbthelper(["show_downstream", "c"])
+        results = self.run_dbthelper(["show-downstream", "c"])
         self.assertTrue(len(results) == 2)
 
     def test_bad_model_arg(self):
         self.run_dbt(["run"])
-        results = self.run_dbthelper(["show_downstream", "non_existent_model"])
+        results = self.run_dbthelper(["show-downstream", "non_existent_model"])
         self.assertTrue(len(results) == 0)

--- a/test/integration/006_source_schema_test/test_source_schemas.py
+++ b/test/integration/006_source_schema_test/test_source_schemas.py
@@ -4,13 +4,13 @@ from test.integration.base import DBTIntegrationTest
 class SourceSchemaTest(DBTIntegrationTest):
     def test_dependencies(self):
         self.run_dbt(["run"])
-        results = self.run_dbthelper(["show_upstream", "d"])
+        results = self.run_dbthelper(["show-upstream", "d"])
         self.assertTrue(len(results) == 5)
-        results = self.run_dbthelper(["show_downstream", "d"])
+        results = self.run_dbthelper(["show-downstream", "d"])
         self.assertTrue(len(results) == 1)
-        results = self.run_dbthelper(["show_upstream", "c"])
+        results = self.run_dbthelper(["show-upstream", "c"])
         self.assertTrue(len(results) == 4)
-        results = self.run_dbthelper(["show_downstream", "c"])
+        results = self.run_dbthelper(["show-downstream", "c"])
         self.assertTrue(len(results) == 2)
 
     def test_compare(self):


### PR DESCRIPTION
Resolves #29 

Swaps the `show_upstream` and `show_downstream` commands for `show-upstream` and `show-downstream` respectively. A deprecation warning is thrown when the old syntax is used, which can easily be dropped in the future.
